### PR TITLE
fix module version for terraform 0.11 compatibility

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ terraform {
 # ---------------------------------------
 
 module "airflow_labels" {
-  source    = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=master"
+  source    = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=0.2.1"
   namespace = "${var.cluster_name}"
   stage     = "${var.cluster_stage}"
   name      = "airflow"
@@ -19,7 +19,7 @@ module "airflow_labels" {
 }
 
 module "airflow_labels_scheduler" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=master"
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=0.2.1"
   namespace  = "${var.cluster_name}"
   stage      = "${var.cluster_stage}"
   name       = "airflow"
@@ -28,7 +28,7 @@ module "airflow_labels_scheduler" {
 }
 
 module "airflow_labels_webserver" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=master"
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=0.2.1"
   namespace  = "${var.cluster_name}"
   stage      = "${var.cluster_stage}"
   name       = "airflow"
@@ -37,7 +37,7 @@ module "airflow_labels_webserver" {
 }
 
 module "airflow_labels_worker" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=master"
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=0.2.1"
   namespace  = "${var.cluster_name}"
   stage      = "${var.cluster_stage}"
   name       = "airflow"
@@ -125,6 +125,7 @@ POLICY
 
 module "sg_airflow" {
   source = "terraform-aws-modules/security-group/aws"
+  version = "v2.17.0"
   name = "${module.airflow_labels.id}-sg"
   description = "Security group for ${module.airflow_labels.id} machines"
   vpc_id = "${data.aws_vpc.default.id}"
@@ -433,6 +434,7 @@ resource "aws_instance" "airflow_worker" {
 
 module "sg_database" {
   source = "terraform-aws-modules/security-group/aws"
+  version = "v2.17.0"
   name = "${module.airflow_labels.id}-database-sg"
   description = "Security group for ${module.airflow_labels.id} database"
   vpc_id = "${data.aws_vpc.default.id}"


### PR DESCRIPTION
When using this module (v0.7.2) with terraform 0.11, bellowed modules used in this repo is point to master branch, those repo's master currently upgrade to terraform 0.12 compatible version already. which cause the terraform version conflict.

Change version tag for them to solve version incompatible issue.