### PR TITLE
feat: Allowed user defined instance subnet and db subnet group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -160,7 +160,7 @@ resource "aws_instance" "airflow_webserver" {
   ami = "${var.ami}"
   key_name = "${aws_key_pair.auth.id}"
   vpc_security_group_ids = ["${module.sg_airflow.this_security_group_id}"]
-  subnet_id = "${tolist(data.aws_subnet_ids.selected.ids)[count.index]}"
+  subnet_id = coalesce("${var.instance_subnet_id}", "${tolist(data.aws_subnet_ids.selected.ids)[count.index]}")
   iam_instance_profile = "${module.ami_instance_profile.instance_profile_name}"
 
   associate_public_ip_address = true
@@ -254,7 +254,7 @@ resource "aws_instance" "airflow_scheduler" {
   ami = "${var.ami}"
   key_name = "${aws_key_pair.auth.id}"
   vpc_security_group_ids = ["${module.sg_airflow.this_security_group_id}"]
-  subnet_id = "${tolist(data.aws_subnet_ids.selected.ids)[count.index]}"
+  subnet_id = coalesce("${var.instance_subnet_id}", "${tolist(data.aws_subnet_ids.selected.ids)[count.index]}")
   iam_instance_profile = "${module.ami_instance_profile.instance_profile_name}"
 
   associate_public_ip_address = true
@@ -348,7 +348,7 @@ resource "aws_instance" "airflow_worker" {
   ami = "${var.ami}"
   key_name = "${aws_key_pair.auth.id}"
   vpc_security_group_ids = ["${module.sg_airflow.this_security_group_id}"]
-  subnet_id = "${tolist(data.aws_subnet_ids.selected.ids)[count.index]}"
+  subnet_id = coalesce("${var.instance_subnet_id}", "${tolist(data.aws_subnet_ids.selected.ids)[count.index]}")
   iam_instance_profile = "${module.ami_instance_profile.instance_profile_name}"
 
   associate_public_ip_address = true
@@ -481,4 +481,5 @@ resource "aws_db_instance" "airflow_database" {
   skip_final_snapshot = true
   vpc_security_group_ids = ["${module.sg_database.this_security_group_id}"]
   port = "5432"
+  db_subnet_group_name = "${var.db_subnet_group_name}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -145,6 +145,12 @@ variable "azs" {
   }
 }
 
+variable "instance_subnet_id" {
+  description = "subnet id used for ec2 instances running airflow, if not defined, vpc's first element in subnetlist will be used"
+  type        = "string"
+  default     = ""
+}
+
 variable "webserver_instance_type" {
   description = "Instance type for the Airflow Webserver."
   type        = "string"
@@ -231,6 +237,12 @@ variable "db_allocated_storage" {
   description = "Dabatase disk size."
   type        = "string"
   default     = 20
+}
+
+variable "db_subnet_group_name" {
+  description = "db subnet group, if assigned, db will create in that subnet, default create in default vpc"
+  type        = "string"
+  default     = ""
 }
 
 #------------------------------------------------------------


### PR DESCRIPTION
I've append subnet parameters in ec2 instances using coalesce, so it won't break any existing usage. if provide `var.instance_subnet_id` it will create ec2 in that subnet, instead of using VPC's existing subnet list.

add db_subnet_group_name parameter(default as "") in aws_db_instance resource block, if not specified `var.db_subnet_group_name` variable, it will launch rds instance in default VPC (which is the same behavior with current version), if defined this variable, rds will be created based on subnet group (allowed user to launch RDS in  their specified subnet)

Related issue: #18 