### PR TITLE
Add custom tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ module "airflow-cluster" {
   vpc_id              = "some-vpc-id"                     # Use default if not provided  
   custom_requirements = "path/to/custom/requirements.txt" # See examples/custom_requirements for more details
   custom_env          = "path/to/custom/env"              # See examples/custom_env for more details
+  tags = {
+    FirstKey          = "first-value"                     # Additional tags to use on resources
+    SecondKey         = "second-value"
+  }
   load_example_dags   = false
   load_default_conns  = false
   rbac                = true                              # See examples/rbac for more details

--- a/examples/deploy/main.tf
+++ b/examples/deploy/main.tf
@@ -18,4 +18,8 @@ module "airflow_cluster" {
   key_name          = "airflow-example-deploy-key"
   vpc_id            = "${data.aws_vpc.default.id}"
   load_example_dags = false
+  tags = {
+    Role            = "airflow-infrastructure"
+    Team            = "AI Labs"
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -11,38 +11,42 @@ terraform {
 # ---------------------------------------
 
 module "airflow_labels" {
-  source    = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=master"
+  source    = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.4.0"
   namespace = "${var.cluster_name}"
   stage     = "${var.cluster_stage}"
   name      = "airflow"
   delimiter = "-"
+  tags      = "${var.tags}"
 }
 
 module "airflow_labels_scheduler" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=master"
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.4.0"
   namespace  = "${var.cluster_name}"
   stage      = "${var.cluster_stage}"
   name       = "airflow"
   attributes = ["scheduler"]
   delimiter  = "-"
+  tags       = "${var.tags}"
 }
 
 module "airflow_labels_webserver" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=master"
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.4.0"
   namespace  = "${var.cluster_name}"
   stage      = "${var.cluster_stage}"
   name       = "airflow"
   attributes = ["webserver"]
   delimiter  = "-"
+  tags       = "${var.tags}"
 }
 
 module "airflow_labels_worker" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=master"
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.4.0"
   namespace  = "${var.cluster_name}"
   stage      = "${var.cluster_stage}"
   name       = "airflow"
   attributes = ["worker"]
   delimiter  = "-"
+  tags       = "${var.tags}"
 }
 
 resource "aws_key_pair" "auth" {

--- a/variables.tf
+++ b/variables.tf
@@ -84,6 +84,11 @@ variable "load_default_conns" {
   default     = false
 }
 
+variable "tags" {
+  description = "Additional tags used into terraform-terraform-labels module."
+  type = "map"
+}
+
 variable "rbac" {
   description = "Enable support for Role-Based Access Control (RBAC)."
   type        = "string"


### PR DESCRIPTION
At Expedia we tag resources with specific tags related to project, etc. If these tags are not present, resources will be automatically deleted. Therefore, I implemented the missing tags into `terraform-terraform-label` modules.

I also added a specific version for the `terraform-terraform-label` source. With the cluster in production, using `master` will definitely introduce a risk factor, as mentioned into their documentation. Unfortunately, we [cannot use variables into source](https://github.com/hashicorp/terraform/issues/1439).

From their [documentation](https://github.com/cloudposse/terraform-terraform-label#usage):
> IMPORTANT: The master branch is used in source just as an example. In your code, do not pin to master because there may be breaking changes between releases. Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our latest releases.